### PR TITLE
Fix double callback calls

### DIFF
--- a/lib/unimail-office365.js
+++ b/lib/unimail-office365.js
@@ -136,11 +136,11 @@ class Office365Connector extends EventEmitter {
                     .get()
                     .then((resMessage) => {
 
-                        return callback(null, resMessage);
+                        return process.nextTick(() => callback(null, resMessage));
                     })
                     .catch((err_) => {
 
-                        return callback(internals.wrapError(err_));
+                        return process.nextTick(() => callback(internals.wrapError(err_)));
                     });
             }
 
@@ -153,20 +153,20 @@ class Office365Connector extends EventEmitter {
                 .then((resMessage) => {
 
                     if (options.raw) {
-                        return callback(null, resMessage);
+                        return process.nextTick(() => callback(null, resMessage));
                     }
 
                     return this._transformMessages(resMessage, auth, (err, transformedMessages) => {
 
                         if (err) {
-                            return callback(err);
+                            return process.nextTick(() => callback(err));
                         }
 
                         const transformedMessage = transformedMessages[0];
                         const hasInlineImg = (resMessage.body.content.indexOf('cid:') > 0);
 
                         if (!transformedMessage.attachments && !hasInlineImg) {
-                            return callback(null, transformedMessage);
+                            return process.nextTick(() => callback(null, transformedMessage));
                         }
 
                         // Only select the properties we need so we don't fetch the content bytes (for performance reasons)
@@ -187,17 +187,17 @@ class Office365Connector extends EventEmitter {
                                     transformedMessage.files = this._transformFiles(resFiles.value);
                                 }
 
-                                return callback(null, transformedMessage);
+                                return process.nextTick(() => callback(null, transformedMessage));
                             })
                             .catch((err_) => {
 
-                                return callback(internals.wrapError(err_));
+                                return process.nextTick(() => callback(internals.wrapError(err_)));
                             });
                     });
                 })
                 .catch((err_) => {
 
-                    return callback(internals.wrapError(err_));
+                    return process.nextTick(() => callback(internals.wrapError(err_)));
                 });
         });
     }
@@ -519,21 +519,24 @@ class Office365Connector extends EventEmitter {
 
                     return Wreck.get(attachment.url).then((result) => {
 
-                        return callback(null, {
-                            '@odata.type': '#microsoft.graph.FileAttachment',
-                            name: attachment.name,
-                            contentLocation: attachment.url,
-                            contentBytes: Buffer.from(result.payload).toString('base64')
+                        return process.nextTick(() => {
+
+                            return callback(null, {
+                                '@odata.type': '#microsoft.graph.FileAttachment',
+                                name: attachment.name,
+                                contentLocation: attachment.url,
+                                contentBytes: Buffer.from(result.payload).toString('base64')
+                            });
                         });
                     })
                         .catch((err) => {
 
                             if (err) {
                                 if (err.data && err.data.payload) {
-                                    return callback(err.data.payload);
+                                    return process.nextTick(() => callback(err.data.payload));
                                 }
 
-                                return callback(err);
+                                return process.nextTick(() => callback(err));
                             }
                         });
                 }, (err, convertedAttachments) => {
@@ -648,7 +651,7 @@ class Office365Connector extends EventEmitter {
                 .then((resMessages) => {
 
                     if (!resMessages || !resMessages.value || resMessages.value.length === 0) {
-                        return callback(null, { files: [] });
+                        return process.nextTick(() => callback(null, { files: [] }));
                     }
 
                     return Async.eachLimit(resMessages.value, concurrentLimitFiles, (message, callback) => {
@@ -660,7 +663,7 @@ class Office365Connector extends EventEmitter {
                             .then((resFiles) => {
 
                                 if (!resFiles) {
-                                    return callback();
+                                    return process.nextTick(() => callback());
                                 }
 
                                 if (!options.raw) {
@@ -672,20 +675,20 @@ class Office365Connector extends EventEmitter {
 
                                 files = [...files, ...resFiles.value];
 
-                                return callback();
+                                return process.nextTick(() => callback());
                             })
                             .catch((err) => {
 
-                                return callback(err);
+                                return process.nextTick(() => callback(err));
                             });
                     }, (err) => {
 
                         if (err) {
-                            return callback(internals.wrapError(err));
+                            return process.nextTick(() => callback(internals.wrapError(err)));
                         }
 
                         if (options.raw) {
-                            return callback(null, files);
+                            return process.nextTick(() => callback(null, files));
                         }
 
                         const filesResponse = { files: this._transformFiles(files) };
@@ -694,12 +697,12 @@ class Office365Connector extends EventEmitter {
                             filesResponse.next_page_token = resMessages['@odata.nextLink'];
                         }
 
-                        return callback(null, filesResponse);
+                        return process.nextTick(() => callback(null, filesResponse));
                     });
                 })
                 .catch((err_) => {
 
-                    return callback(internals.wrapError(err_));
+                    return process.nextTick(() => callback(internals.wrapError(err_)));
                 });
         });
     }
@@ -747,19 +750,22 @@ class Office365Connector extends EventEmitter {
                 .get()
                 .then((resFile) => {
 
-                    return callback(null, {
-                        size: resFile.size,
-                        file_name: resFile.name,
-                        type: resFile.contentType,
-                        service_file_id: resFile.id,
-                        service_message_id: params.messageId,
-                        data: resFile.contentBytes,
-                        file_id: resFile.contentId
+                    return process.nextTick(() => {
+
+                        return callback(null, {
+                            size: resFile.size,
+                            file_name: resFile.name,
+                            type: resFile.contentType,
+                            service_file_id: resFile.id,
+                            service_message_id: params.messageId,
+                            data: resFile.contentBytes,
+                            file_id: resFile.contentId
+                        });
                     });
                 })
                 .catch((err_) => {
 
-                    return callback(err_);
+                    return process.nextTick(() => callback(err_));
                 });
         });
     }
@@ -853,11 +859,11 @@ class Office365Connector extends EventEmitter {
         getRequest.get()
             .then((res) => {
 
-                return callback(null, res);
+                return process.nextTick(() => callback(null, res));
             })
             .catch((err) => {
 
-                return callback(err);
+                return process.nextTick(() => callback(err));
             });
     }
 
@@ -887,16 +893,16 @@ class Office365Connector extends EventEmitter {
                             this.emit('error', err);
                         }
 
-                        return callback(null, result.internetMessageId);
+                        return process.nextTick(() => callback(null, result.internetMessageId));
                     })
                     .catch((err) => {
 
-                        return callback(internals.wrapError(err));
+                        return process.nextTick(() => callback(internals.wrapError(err)));
                     });
             })
             .catch((err) => {
 
-                return callback(internals.wrapError(err));
+                return process.nextTick(() => callback(internals.wrapError(err)));
             });
     }
 
@@ -931,20 +937,20 @@ class Office365Connector extends EventEmitter {
 
                                 return client.api(`/me/messages/${response.id}/send`).post({}).then(() => {
 
-                                    return callback(null, updateResponse.internetMessageId);
+                                    return process.nextTick(() => callback(null, updateResponse.internetMessageId));
                                 }).catch((err) => {
 
-                                    return callback(internals.wrapError(err));
+                                    return process.nextTick(() => callback(internals.wrapError(err)));
                                 });
                             })
                             .catch((err) => {
 
-                                return callback(internals.wrapError(err));
+                                return process.nextTick(() => callback(internals.wrapError(err)));
                             });
                     })
                     .catch((err) => {
 
-                        return callback(internals.wrapError(err));
+                        return process.nextTick(() => callback(internals.wrapError(err)));
                     });
             })
             .catch((err) => {
@@ -956,7 +962,7 @@ class Office365Connector extends EventEmitter {
                     return this._sendMessage(message, client, callback);
                 }
 
-                return callback(internals.wrapError(err));
+                return process.nextTick(() => callback(internals.wrapError(err)));
             });
     }
 
@@ -1670,11 +1676,11 @@ internals.getFolders = (auth, callback) => {
                 }
             });
 
-            return callback(null, folders);
+            return process.nextTick(() => callback(null, folders));
         })
         .catch((err) => {
 
-            return callback(err);
+            return process.nextTick(() => callback(err));
         });
 };
 


### PR DESCRIPTION
Wrap callbacks inside async code in process.nextTick(). This makes sure any further errors won't get caught by the promise chain.

fixes: https://github.com/Salesflare/Server/issues/11617