### PR TITLE
Fixes email reply threading for Gmail and Office365

### DIFF
--- a/lib/unimail-gmail.js
+++ b/lib/unimail-gmail.js
@@ -570,6 +570,14 @@ class GmailConnector extends EventEmitter {
                             return this.getMessage(auth, { id: sendResponseWithoutThread.id }, (err, getMessageResponse) => {
 
                                 if (err) {
+                                    if (returnMetadata) {
+                                        return callback(null, {
+                                            email_message_id: null,
+                                            service_message_id: sendResponseWithoutThread.id,
+                                            service_thread_id: sendResponseWithoutThread.threadId
+                                        });
+                                    }
+
                                     return callback();
                                 }
 
@@ -593,6 +601,14 @@ class GmailConnector extends EventEmitter {
                 return this.getMessage(auth, { id: sendResponse.id }, (err, getMessageResponse) => {
 
                     if (err) {
+                        if (returnMetadata) {
+                            return callback(null, {
+                                email_message_id: null,
+                                service_message_id: sendResponse.id,
+                                service_thread_id: sendResponse.threadId
+                            });
+                        }
+
                         return callback();
                     }
 

--- a/lib/unimail-gmail.js
+++ b/lib/unimail-gmail.js
@@ -477,8 +477,13 @@ class GmailConnector extends EventEmitter {
      * @param {String} params.text - Plain text content of message
      * @param {String} params.html - Html content of message
      * @param {String} params.subject - Subject of message,
-     * @param {String} params.inReplyTo - The message id this message is replying
-     * @param {String} params.threadId - Id of the thread this message should be created in
+     * @param {String} [params.inReplyTo] - The RFC message-id this message is replying to (legacy)
+     * @param {String} [params.references] - RFC References header value (legacy)
+     * @param {String} [params.threadId] - Gmail thread id (legacy)
+     * @param {Object} [params.replyTo] - Provider-aware reply target (preferred over inReplyTo/threadId)
+     * @param {String} [params.replyTo.emailMessageId] - RFC internet message id of the original
+     * @param {String} [params.replyTo.serviceThreadId] - Gmail thread id of the original
+     * @param {String} [params.replyTo.references] - References header value
      * @param {MessageRecipient} params.from
      * @param {MessageRecipient[]} params.to
      * @param {MessageRecipient[]} params.cc
@@ -486,8 +491,9 @@ class GmailConnector extends EventEmitter {
      * @param {{ name: String, url: String }[]} params.attachments
      *
      * @param {Object} options
+     * @param {Boolean} [options.returnMetadata] - When true, callback receives { email_message_id, service_message_id, service_thread_id } instead of a plain string
      *
-     * @param {function(Error?, String?):void} callback
+     * @param {function(Error?, String | { email_message_id: String, service_message_id: String, service_thread_id: String }):void} callback
      *
      * @returns {void}
      */
@@ -495,7 +501,10 @@ class GmailConnector extends EventEmitter {
 
         if (typeof options === 'function') {
             callback = options;
+            options = {};
         }
+
+        const returnMetadata = options && options.returnMetadata;
 
         const mailOptions = {
             from: internals.convertMessageRecipientsToCsv(params.from),
@@ -505,7 +514,8 @@ class GmailConnector extends EventEmitter {
             text: params.text,
             html: params.html,
             subject: params.subject,
-            inReplyTo: params.inReplyTo
+            inReplyTo: params.replyTo?.emailMessageId || params.inReplyTo,
+            references: params.replyTo?.references || params.references
         };
 
         if (params.attachments && params.attachments.length > 0) {
@@ -537,8 +547,10 @@ class GmailConnector extends EventEmitter {
                 }
             };
 
-            if (params.threadId) {
-                gmailSendParams.requestBody = { threadId: params.threadId };
+            const threadId = params.replyTo?.serviceThreadId || params.threadId;
+
+            if (threadId) {
+                gmailSendParams.requestBody = { threadId };
             }
 
             return this._callAPI(Gmail.users.messages.send.bind(Gmail.users.messages), gmailSendParams, (err, sendResponse) => {
@@ -561,6 +573,14 @@ class GmailConnector extends EventEmitter {
                                     return callback();
                                 }
 
+                                if (returnMetadata) {
+                                    return callback(null, {
+                                        email_message_id: getMessageResponse.email_message_id,
+                                        service_message_id: sendResponseWithoutThread.id,
+                                        service_thread_id: sendResponseWithoutThread.threadId
+                                    });
+                                }
+
                                 return callback(null, getMessageResponse.email_message_id);
                             });
                         });
@@ -574,6 +594,14 @@ class GmailConnector extends EventEmitter {
 
                     if (err) {
                         return callback();
+                    }
+
+                    if (returnMetadata) {
+                        return callback(null, {
+                            email_message_id: getMessageResponse.email_message_id,
+                            service_message_id: sendResponse.id,
+                            service_thread_id: sendResponse.threadId
+                        });
                     }
 
                     return callback(null, getMessageResponse.email_message_id);

--- a/lib/unimail-office365.js
+++ b/lib/unimail-office365.js
@@ -15,7 +15,11 @@ const internals = {
     paramTypes: {
         search: 'search',
         filter: 'filter'
-    }
+    },
+    // Opt in to stable IDs that survive folder moves (e.g. Drafts → Sent Items).
+    // Must be sent on every request where the returned id property will be stored or reused later.
+    // https://learn.microsoft.com/en-us/graph/outlook-immutable-id
+    PREFER_IMMUTABLE_ID: 'IdType="ImmutableId"'
 };
 
 // Needed because of https://docs.microsoft.com/en-us/graph/throttling#outlook-service-limits and fix for https://github.com/Salesflare/Server/issues/6616
@@ -476,7 +480,9 @@ class Office365Connector extends EventEmitter {
      * @param {String} params.text - Plain text content of message
      * @param {String} params.html - Html content of message
      * @param {String} params.subject - Subject of message,
-     * @param {String} params.inReplyTo - The message id this message is replying
+     * @param {String} [params.inReplyTo] - The RFC internet message id this message is replying to (legacy, only used when params.replyTo is absent)
+     * @param {Object} [params.replyTo] - Provider-aware reply target (preferred over inReplyTo)
+     * @param {String} [params.replyTo.serviceMessageId] - Microsoft Graph message id of the original (used for createReply)
      * @param {MessageRecipient} params.from
      * @param {MessageRecipient[]} params.to
      * @param {MessageRecipient[]} params.cc
@@ -484,8 +490,9 @@ class Office365Connector extends EventEmitter {
      * @param {{ name: String, url: String, contentBytes: any }[]} params.attachments
      *
      * @param {Object} options
+     * @param {Boolean} [options.returnMetadata] - When true, callback receives { email_message_id, service_message_id, service_thread_id } instead of a plain string
      *
-     * @param {function(Error, Object):void} callback
+     * @param {function(Error, String | { email_message_id: String, service_message_id: String, service_thread_id: String }):void} callback
      *
      * @returns {void}
      */
@@ -499,6 +506,8 @@ class Office365Connector extends EventEmitter {
             callback = options;
             options = {};
         }
+
+        const returnMetadata = options && options.returnMetadata;
 
         return Async.parallel({
             refreshToken: Async.apply(this._refreshTokenIfNeeded.bind(this), auth),
@@ -587,11 +596,18 @@ class Office365Connector extends EventEmitter {
                 message.bccRecipients = params.bcc.map(internals.convertUnimailToMSGraphRecipient);
             }
 
-            if (params.inReplyTo) {
-                return this._reply(message, params, client, callback);
+            const replyServiceMessageId = params.replyTo?.serviceMessageId;
+
+            if (replyServiceMessageId) {
+                return this._reply(message, { ...params, inReplyTo: replyServiceMessageId }, client, callback, returnMetadata);
             }
 
-            return this._sendMessage(message, client, callback);
+            // Backward-compat: honour inReplyTo for non-workflow / old callers that don't supply replyTo
+            if (params.inReplyTo && !params.replyTo) {
+                return this._reply(message, params, client, callback, returnMetadata);
+            }
+
+            return this._sendMessage(message, client, callback, returnMetadata);
         });
     }
 
@@ -870,14 +886,16 @@ class Office365Connector extends EventEmitter {
     /**
      * @param {Object} message
      * @param {MicrosoftGraph.Client} client - The microsoft graph client
-     * @param {function(Error, Object):void} callback
+     * @param {function(Error, String | { email_message_id: String, service_message_id: String, service_thread_id: String }):void} callback
+     * @param {Boolean} [returnMetadata]
      * @returns {void}
      */
-    _sendMessage(message, client, callback) {
+    _sendMessage(message, client, callback, returnMetadata) {
 
         // `/sendMail` doesn't return an id, or anything for that matter.
-        // So we have to create a draft first and then send
-        client.api('/me/messages').post(message)
+        // So we have to create a draft first and then send.
+        // ImmutableId ensures the returned id stays valid after the message moves to Sent Items.
+        client.api('/me/messages').header('Prefer', internals.PREFER_IMMUTABLE_ID).post(message)
             .then((result) => {
 
                 return client.api(`/me/messages/${result.id}/send`).post({})
@@ -891,6 +909,17 @@ class Office365Connector extends EventEmitter {
                             err.id = result.id;
                             err.mail_message = message;
                             this.emit('error', err);
+                        }
+
+                        if (returnMetadata) {
+                            return process.nextTick(() => {
+
+                                return callback(null, {
+                                    email_message_id: result.internetMessageId,
+                                    service_message_id: result.id,
+                                    service_thread_id: result.conversationId
+                                });
+                            });
                         }
 
                         return process.nextTick(() => callback(null, result.internetMessageId));
@@ -910,21 +939,24 @@ class Office365Connector extends EventEmitter {
      * @param {Object} message
      * @param {{ inReplyTo: String }} params
      * @param {MicrosoftGraph.Client} client - The microsoft graph client
-     * @param {function(Error, Object):void} callback
+     * @param {function(Error, String | { email_message_id: String, service_message_id: String, service_thread_id: String }):void} callback
+     * @param {Boolean} [returnMetadata]
      * @returns {void}
      */
-    _reply(message, params, client, callback) {
+    _reply(message, params, client, callback, returnMetadata) {
 
         // `/reply` doesn't return an id, or anything for that matter.
-        // So we have to create a draft first and set everything we want manually and then send
-        client.api(`/me/messages/${params.inReplyTo}/createReply`).post({})
+        // So we have to create a draft first and set everything we want manually and then send.
+        // ImmutableId on createReply ensures response.id stays valid for the subsequent PATCH/attachments/send calls.
+        // ImmutableId on PATCH ensures updateResponse.id is stable for storage as service_message_id.
+        client.api(`/me/messages/${params.inReplyTo}/createReply`).header('Prefer', internals.PREFER_IMMUTABLE_ID).post({})
             .then((response) => {
 
                 // Remove the attachments from message to prevent double attachments if PATCH /messages starts supporting attachments
                 const attachments = [...(message.attachments || [])];
                 delete message.attachments;
 
-                return client.api(`/me/messages/${response.id}`).patch(message)
+                return client.api(`/me/messages/${response.id}`).header('Prefer', internals.PREFER_IMMUTABLE_ID).patch(message)
                     .then((updateResponse) => {
 
                         const attachmentPromises = attachments.map((attachment) => {
@@ -936,6 +968,17 @@ class Office365Connector extends EventEmitter {
                             .then(() => {
 
                                 return client.api(`/me/messages/${response.id}/send`).post({}).then(() => {
+
+                                    if (returnMetadata) {
+                                        return process.nextTick(() => {
+
+                                            return callback(null, {
+                                                email_message_id: updateResponse.internetMessageId,
+                                                service_message_id: updateResponse.id,
+                                                service_thread_id: updateResponse.conversationId
+                                            });
+                                        });
+                                    }
 
                                     return process.nextTick(() => callback(null, updateResponse.internetMessageId));
                                 }).catch((err) => {
@@ -959,7 +1002,7 @@ class Office365Connector extends EventEmitter {
                 // Hotmail for example seems to return a 404 resource not found while Outlook returns a 400 bad request
                 // Office365 mailboxes can also return this vague 'Mailbox move in progress' error when attempting to reply to a message from another inbox.
                 if ((err.statusCode >= 400 && err.statusCode <= 404) || (err.statusCode === 503 && err.message?.toLowerCase()?.includes('mailbox move in progress'))) {
-                    return this._sendMessage(message, client, callback);
+                    return this._sendMessage(message, client, callback, returnMetadata);
                 }
 
                 return process.nextTick(() => callback(internals.wrapError(err)));


### PR DESCRIPTION
**Problem**
Workflow reply steps were not threading correctly:

- Gmail: threadId was never passed to the Gmail send API, so replies always created a new thread.

- Office365: createReply was called with the RFC internetMessageId instead of the Microsoft Graph message id, causing an immediate 404 on every reply attempt. Additionally, stored Graph ids were mutable and would become invalid once a message moved from Drafts to Sent Items.

**Changes**
Adds a params.replyTo object ({ emailMessageId, serviceThreadId/serviceMessageId, references }) as the preferred reply target for both providers. Existing flat params (inReplyTo, threadId) remain as fallbacks — no breaking changes.
Gmail: populates In-Reply-To, References, and threadId from replyTo.
Office365: routes createReply to replyTo.serviceMessageId (the Graph id). Adds Prefer: IdType="ImmutableId" to draft creation and reply draft calls so stored ids survive the Drafts → Sent Items move.
Adds options.returnMetadata to both providers: returns { email_message_id, service_message_id, service_thread_id } instead of a plain string, letting the Server store provider ids immediately without waiting for sent webhooks.
